### PR TITLE
Long-form generation

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -7,6 +7,8 @@ from typing import Optional, Dict, Type, Union
 from pathlib import Path
 from dataclasses import dataclass
 import io
+import nltk
+import numpy as np
 
 from mars5.model import CodecLM, ResidualTransformer
 from vocos import Vocos
@@ -63,6 +65,14 @@ class InferenceConfig():
     beam_width: int = 1 # only beam width of 1 is currently supported
     ref_audio_pad: float = 0
 
+    # How many characters are in the sliding window that chunks the text if it
+    # is too long.
+    sliding_window_size: int = 120
+
+    # If True, we use the generated audio from the previous chunk as the reference
+    # If False, the reference provided by the user is always used.
+    sliding_window_continuous: bool = True
+
 class Mars5TTS(nn.Module, ModelHubMixin):
     def __init__(self, ar_ckpt, nar_ckpt, device: str = None) -> None:
         super().__init__()
@@ -97,7 +107,6 @@ class Mars5TTS(nn.Module, ModelHubMixin):
                                             p_cond_drop=0, dropout=0)
         self.codecnar.load_state_dict(nar_ckpt['model'])
         self.codecnar = self.codecnar.to(self.device).eval()
-        self.default_T = 200
 
         self.sr = 24000
         self.latent_sr = 75
@@ -106,6 +115,9 @@ class Mars5TTS(nn.Module, ModelHubMixin):
         self.vocos = Vocos.from_pretrained("charactr/vocos-encodec-24khz").to(self.device).eval()
         nuke_weight_norm(self.codec)
         nuke_weight_norm(self.vocos)
+
+        # Download `punkt` for sentence segmentation
+        nltk.download('punkt', quiet=True)
 
     @classmethod
     def _from_pretrained(
@@ -184,9 +196,47 @@ class Mars5TTS(nn.Module, ModelHubMixin):
         # pass through transformer
         res = self.codeclm.spk_encoder(spk_seq, is_causal=False, src_key_padding_mask=src_key_padding_mask)[:, :1] # select first element -> now (bs, 1, dim).
         return res.squeeze(1)
+    
+    def tts(self, text: str, ref_audio: Tensor, ref_transcript: Optional[str] = None, 
+            cfg: Optional[InferenceConfig] = InferenceConfig()) -> Tensor:
+
+        sentences = nltk.tokenize.sent_tokenize(text)
+        text_chunks = []
+
+        for sentence in sentences:
+
+            # Handle sentences that are too long
+            while len(sentence) > cfg.sliding_window_size:
+                split_whitespace = sentence.index(' ', cfg.sliding_window_size)
+                chunk, sentence = sentence[:split_whitespace], sentence[split_whitespace:]
+                text_chunks.append(chunk)
+
+            # Chunk sentences together
+            if text_chunks and len(sentence) + len(text_chunks[-1]) <= cfg.sliding_window_size:
+                text_chunks[-1] += ' ' + sentence
+            else:
+                text_chunks.append(sentence)
+
+        text_chunks.insert(0, ref_transcript)
+        audios = [ref_audio]
+        ar_codes = []
+
+        for ref_chunk, current_chunk in zip(text_chunks, text_chunks[1:]):
+            ref_chunk_audio = audios[-1]
+            current_chunk_ar_codes, current_chunk_audio = self.custom_tts_one_chunk(
+                text=current_chunk,
+                ref_audio=ref_chunk_audio if cfg.sliding_window_continuous else ref_audio,
+                ref_transcript=ref_chunk if cfg.sliding_window_continuous else ref_transcript,
+                cfg=cfg,
+            )
+            audios.append(current_chunk_audio)
+            ar_codes.append(current_chunk_ar_codes.cpu())
+
+        final_audio = np.hstack(audios[1:])
+        return ar_codes, final_audio
 
     @torch.inference_mode
-    def tts(self, text: str, ref_audio: Tensor, ref_transcript: Optional[str] = None, 
+    def tts_chunk(self, text: str, ref_audio: Tensor, ref_transcript: Optional[str] = None, 
             cfg: Optional[InferenceConfig] = InferenceConfig()) -> Tensor:
         """ Perform TTS for `text`, given a reference audio `ref_audio` (of shape [sequence_length,], sampled at 24kHz) 
         which has an associated `ref_transcript`. Perform inference using the inference 
@@ -270,8 +320,7 @@ class Mars5TTS(nn.Module, ModelHubMixin):
         x_padding_mask = torch.zeros((1, _x.shape[1]), dtype=torch.bool, device=_x.device)
 
         # ---> perform DDPM NAR inference
-        T = self.default_T
-        diff = MultinomialDiffusion(self.diffusion_n_classes, timesteps=T, device=self.device)
+        diff = MultinomialDiffusion(self.diffusion_n_classes, timesteps=cfg.timesteps, device=self.device)
 
         dsh_cfg = DSH(last_greedy=True, x_0_temp=cfg.x_0_temp, 
                         guidance_w=cfg.nar_guidance_w, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchvision
 torchaudio
-numpy
+numpy<2
 regex
 librosa
 vocos


### PR DESCRIPTION
I have implemented this simple method to generate long-form content with MARS5. It splits the text into multiple chunks and generates audio for each chunk individually. These are then joined. There are two ways how this could work: (1) Either it can reuse the reference provided by the user `sliding_window_reuse_reference = True`, or (2) it uses the audio generated for the previous chunk as a reference `= False`.

Pros of reusing the same reference:
- It is more robust, i.e., if the generation fails in one chunk, it will not affect the other chunks.
- It is feasible to use a short reference, so the inference is faster and you can use longer sliding windows (meaning less splits)

Cons of reusing the same reference:
- The speech is less fluent. For example, if the reference is a sentence, all the generated audios can have an accent on the start of the speech (as the model expects that it is generating next sentence at that point). This is barely noticeable, but in the examples below, it is possible to hear that the `reuse` sample puts accent on some words.

## Examples

The chunks were as follows:
- An advantage of variance as a measure of dispersion is that it is more amenable to algebraic manipulation than other measures
- of dispersion such as the expected absolute deviation; for example, the variance of a sum of uncorrelated random variables
- is equal to the sum of their variances.
- A disadvantage of the variance for practical applications is that, unlike the standard deviation, its units differ from the
- random variable, which is why the standard deviation is more commonly reported as a measure of dispersion once the calculation
- is finished.

Using the previous chunk as reference
https://github.com/Camb-ai/MARS5-TTS/assets/9572985/f1675439-2865-44b1-834c-a2b82365644e

Reusing the original reference
https://github.com/Camb-ai/MARS5-TTS/assets/9572985/695ed185-a74a-405f-89ff-d016a768eb22

## Sliding window size

I added the size of the sliding window as a `cfg` attribute. It simply counts the number of characters in the input and tries to split the text accordingly. This can be controlled by the user. 