### PR TITLE
Numpy 2.x is not supported, pin requirements to Numpy 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchvision
 torchaudio
-numpy
+numpy==1.26.4
 regex
 librosa
 vocos


### PR DESCRIPTION
Fixes an issues with requirements.  Numpy 2.x is not supported due to something else up the food chain being compiled with 1.x.x.  The code will work with 1.26.4 (Feb 5 2024), which was the final 1.x.x version.

It appears to be from librosa.

To reproduce the bug, just follow instructions from this repo itself. 
Clone repo
(optional) setup venv or conda env
pip install -r requirements.txt
Run sample code from README.md (my example below)

```
import torch
import librosa

mars5, config_class = torch.hub.load('Camb-ai/mars5-tts', 'mars5_english', trust_repo=True)
wav, sr = librosa.load("something_weird_is_going_on.wav", 
                       sr=mars5.sr, mono=True)

wav = torch.from_numpy(wav)
ref_transcript = "Something weird is going on."

cfg = config_class(deep_clone=True, rep_penalty_window=100,
                      top_k=100, temperature=0.7, freq_penalty=3)

ar_codes, output_audio = mars5.tts("The quick brown rat.", wav, 
          ref_transcript,
          cfg=cfg)
```
Result:
```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "/mnt/lcl/nvme/mars-tts-github/test.py", line 8, in <module>
    wav, sr = librosa.load("something_weird_is_going_on.wav",
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/lazy_loader/__init__.py", line 83, in __getattr__
    attr = getattr(submod, name)
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/lazy_loader/__init__.py", line 82, in __getattr__
    submod = importlib.import_module(submod_path)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/librosa/core/audio.py", line 15, in <module>
    import soxr
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/soxr/__init__.py", line 10, in <module>
    from . import cysoxr
Traceback (most recent call last):
  File "/mnt/lcl/nvme/mars-tts-github/test.py", line 8, in <module>
    wav, sr = librosa.load("something_weird_is_going_on.wav", 
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/lazy_loader/__init__.py", line 83, in __getattr__
    attr = getattr(submod, name)
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/lazy_loader/__init__.py", line 82, in __getattr__
    submod = importlib.import_module(submod_path)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/librosa/core/audio.py", line 15, in <module>
    import soxr
  File "/mnt/lcl/nvme/mars-tts-github/venv/lib/python3.10/site-packages/soxr/__init__.py", line 10, in <module>
    from . import cysoxr
  File "src/soxr/cysoxr.pyx", line 1, in init soxr.cysoxr
ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).
```

If you run `pip show numpy`, you'll see you are on 2.0.0, which doesn't seem to work with librosa.  2.0.0 was released June 16, so it's likely this just recently started to cause issues.